### PR TITLE
Debug feature implementations.

### DIFF
--- a/src/debug/dm_mem.py
+++ b/src/debug/dm_mem.py
@@ -1,0 +1,308 @@
+"""
+Copyright Digisim, Computer Architecture team of South China University of Technology,
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   Author Name: Ruohui Chen
+   Date: 2021-05-19
+   File Name: dm_mem.py
+   Description: Memory module for execution-based debug clients
+"""
+from pyhcl import *
+from src.debug.dm_pkg import *
+from src.include.utils import *
+from src.include.pkg import *
+
+
+def dm_mem(NrHarts: int = 1, BusWidth: int = 32, DmBaseAddress: int = 0):
+    # local parameters
+    SelectableHarts = CatBits(*[U.w(1)(1) * NrHarts])
+    DbgAddressBits: int = 12
+    HartSelLen: int = 1 if NrHarts == 1 else clog2(NrHarts)
+    NrHartsAligned: int = 2 ** HartSelLen
+    MaxAar: int = 4 if BusWidth == 64 else 3
+    HasSndScratch = (U(DmBaseAddress) != U(0))
+    # Depending on whether we are at the zero page or not we either use 'x0' of 'x10/a0'
+    LoadBaseAddr = Mux(U(DmBaseAddress == U(0)), U.w(5)(0), U.w(5)(10))
+
+    DataBaseAddr = DataAddr
+    DataEndAddr = DataAddr + U(4) * U(DataCount) - U(1)
+    ProgBufBaseAddr = DataAddr - U(4) * U(DataCount) - U(1)
+    ProgBufEndAddr = DataEndAddr - U(1)
+    AbstractCmdBaseAddr = ProgBufBaseAddr - U(40)
+    AbstractCmdEndAddr = ProgBufBaseAddr - U(1)
+
+    WhereToAddr = U(0x300)
+    FlagsBaseAddr = U(0x400)
+    FlagsEndAddr = U(0x7FF)
+
+    HaltedAddr = U(0x100)
+    GoingAddr = U(0x104)
+    ResumingAddr = U(0x108)
+    ExceptionAddr = U(0x10C)
+
+    # FSM
+    STATE_E_WIDTH = 2
+
+    Idle = U.w(2)(0)
+    Go = U.w(2)(1)
+    Resume = U.w(2)(2)
+    CmdExcuting = U.w(2)(3)
+
+    class DM_MEM(Module):
+        io = IO(
+            debug_req_o=Output(U.w(NrHarts)),
+            hartsel_i=Input(U.w(20)),
+            # from Ctrl and Status register
+            haltreq_i=Input(U.w(NrHarts)),
+            resumereq_i=Input(U.w(NrHarts)),
+            clear_resumeack_i=Input(Bool),
+
+            # state bits
+            halted_o=Output(U.w(NrHarts)),          # hart acknowledge halt
+            resuming_o=Output(U.w(NrHarts)),        # hart is resuming
+
+            progbuf_i=Input(Vec(ProgBufSize, U.w(32))),     # program buffer to expose
+
+            data_i=Input(Vec(DataCount, U.w(32))),      # data in
+            data_o=Output(Vec(DataCount, U.w(32))),     # data out
+            data_valid_o=Output(Bool),                  # data out is valid
+
+            # abstract command interfacae
+            cmd_valid_i=Input(Bool),
+            cmd_i=Input(U.w(32)),       # command_t
+            cmderror_valid_o=Output(Bool),
+            cmderror_o=Output(U.w(CMDERR_E_WIDTH)),
+            cmdbusy_o=Output(Bool),
+
+            # data interface
+
+            # SRAM interface
+            req_i=Input(Bool),
+            we_i=Input(Bool),
+            addr_i=Input(U.w(BusWidth)),
+            wdata_i=Input(U.w(BusWidth)),
+            be_i=Input(U.w(int(BusWidth/8))),
+            rdata_o=Output(U.w(BusWidth))
+        )
+        cmd_i = command_t(False)
+        cmd_i.cmdtype <<= io.cmd_i[31:24]
+        cmd_i.control <<= io.cmd_i[23:0]
+
+        progbuf = Wire(Vec(int(ProgBufSize/2), U.w(64)))
+        abstract_cmd = Wire(Vec(8, U.w(64)))
+        halted = gen_ff(NrHarts, 0)
+        resuming = gen_ff(NrHarts, 0)
+        resume, go, going = [Wire(Bool) for _ in range(3)]
+
+        exception = Wire(Bool)
+        unsupported_command = Wire(Bool)
+
+        rom_rdata = Wire(U.w(64))
+        rdata = gen_ff(64, 0)
+        word_enable32_q = RegInit(Bool(False))
+
+        # this is needed to avoid lint warnings related to array indexing
+        # resize hartsel to valid range
+        hartsel, wdata_hartsel = [Wire(U.w(HartSelLen)) for _ in range(2)]
+
+        resumereq_aligned, haltreq_aligned, halted_d_aligned, halted_aligned, \
+        resumereq_wdata_aligned, resuming_d_aligned = [vec_init_wire(NrHartsAligned, Bool, Bool(False)) for _ in range(6)]
+
+        halted_q_aligned, resuming_q_aligned = [vec_init(NrHartsAligned, Bool, Bool(False)) for _ in range(2)]
+
+        vec_assign(NrHartsAligned, resumereq_aligned, io.resumereq_i)
+        vec_assign(NrHartsAligned, haltreq_aligned, io.haltreq_i)
+        vec_assign(NrHartsAligned, resumereq_wdata_aligned, io.resumereq_i)
+
+        vec_assign(NrHartsAligned, halted_q_aligned, halted.q)
+        vec_assign(NrHartsAligned, halted.d, halted_d_aligned)
+        vec_assign(NrHartsAligned, resuming_q_aligned, resuming.q)
+        vec_assign(NrHartsAligned, resuming.d, resuming_d_aligned)
+
+        # distinguish whether we need to forward data from the ROM or the FSM
+        # latch the address for this
+
+        fwd_rom = gen_ff(1, 0)
+        ac_ar = ac_ar_cmd_t()
+
+        # Abstract Command Access Register
+        ac_ar <<= io.cmd_i
+        io.debug_req_o <<= io.haltreq_i
+        io.halted_o <<= halted.q
+        io.resuming_o <<= resuming.q
+
+        # reshapge progbuf
+        progbuf <<= io.progbuf_i
+
+        state = gen_ff(STATE_E_WIDTH, 0)
+
+        # hart ctrl queue
+        io.cmderror_valid_o <<= Bool(False)
+        io.cmderror_o <<= CmdErrNone
+        state.n <<= state.q
+        go <<= Bool(False)
+        resume <<= Bool(False)
+        io.cmdbusy_o <<= Bool(True)
+
+        # FSM
+        with when(state.q == Idle):
+            io.cmdbusy_o <<= Bool(False)
+            with when(io.cmd_valid_i & halted_q_aligned[hartsel] & (~unsupported_command)):
+                # give the go signal
+                state.n <<= Go
+            with elsewhen(io.cmd_valid_i):
+                # hart must be halted for all requests
+                io.cmderror_valid_o <<= Bool(True)
+                io.cmderror_o <<= CmdErrorHaltResume
+            # CSRs want to resume, the request is ignored when the hart is
+            # requested to halt or it didn't clear the resuming_q bit before
+            with when(resumereq_aligned[hartsel] & (~resuming_q_aligned[hartsel]) &
+                      (~haltreq_aligned[hartsel]) & halted_q_aligned[hartsel]):
+                state.n <<= Resume
+
+        with elsewhen(state.q == Go):
+            # we are already busy here since we scheduled the execution of a program
+            io.cmdbusy_o <<= Bool(True)
+            go <<= Bool(True)
+            # the thread is now executing the command, track its state
+            with when(going):
+                state.n <<= CmdExcuting
+
+        with elsewhen(state.q == Resume):
+            io.cmdbusy_o <<= Bool(True)
+            resume <<= Bool(True)
+            with when(resuming_q_aligned[hartsel]):
+                state.n <<= Idle
+
+        with elsewhen(state.q == CmdExcuting):
+            io.cmdbusy_o <<= Bool(True)
+            go <<= Bool(False)
+            # wait until the hart has halted again
+            with when(halted_aligned[hartsel]):
+                state.n <<= Idle
+
+        # only signal once that cmd is unsupported so that we can clear cmderr
+        # in subsequent writes to abstractcs
+        with when(unsupported_command & io.cmd_valid_i):
+            io.cmderror_valid_o <<= Bool(True)
+            io.cmderror_o <<= CmdErrNotSupported
+
+        with when(exception):
+            io.cmderror_valid_o <<= Bool(True)
+            io.cmderror_o <<= CmdErrorException
+
+        # word mus for 32bit and 64bit buses
+        word_mux = Wire(U.w(64))
+        word_mux <<= Mux(fwd_rom.q, rom_rdata, rdata.q)
+
+        if BusWidth == 64:
+            io.rdata_o <<= word_mux
+        else:
+            io.rdata_o <<= Mux(word_enable32_q, word_mux[63:32], word_mux[31:0])
+
+        # read/write logic
+        data_bits = Wire(U.w(64))
+        rdata_vec = vec_init_wire(8, U.w(8), U(0))
+
+        vec_assign(NrHartsAligned, halted_d_aligned, halted.q)
+        vec_assign(NrHartsAligned, resuming_d_aligned, resuming.q)
+        rdata.n <<= rdata.q
+        # convert the data in bits representation
+        data_bits <<= io.data_i
+
+        # write data in csr register
+        io.data_valid_o <<= Bool(False)
+        exception <<= Bool(False)
+        halted_aligned <<= U(0)
+        going <<= Bool(False)
+
+        #  The resume ack signal is lowered when the resume request is deasserted
+        with when(io.clear_resumeack_i):
+            resuming_d_aligned[hartsel] <<= Bool(False)
+        # we've got a new request
+        with when(io.req_i):
+            # this is a write
+            with when(io.we_i):
+                with when(io.addr_i[DbgAddressBits-1:0] == HaltedAddr):
+                    halted_aligned[wdata_hartsel] <<= Bool(True)
+                with elsewhen(io.addr_i[DbgAddressBits-1:0] == GoingAddr):
+                    going <<= Bool(True)
+                with elsewhen(io.addr_i[DbgAddressBits-1:0] == ResumingAddr):
+                    # clear the halted flag as the hart resumed execution
+                    halted_d_aligned[wdata_hartsel] <<= Bool(False)
+                    #  set the resuming flag which needs to be cleared by the debugger
+                    resuming_d_aligned[wdata_hartsel] <<= Bool(True)
+                with elsewhen(io.addr_i[DbgAddressBits-1:0] == ExceptionAddr):
+                    exception <<= Bool(True)
+                with elsewhen((io.addr_i[DbgAddressBits-1:0] >= DataBaseAddr) &
+                              (io.addr_i[DbgAddressBits-1:0] <= DataEndAddr)):
+                    io.dataa_valid_o <<= Bool(True)
+                    data_bits <<= CatBits(*[Mux(io.be_i[i], io.wdata[i*8+7:i*8], U.w(8)(0))
+                                            for i in range(int(BusWidth/8)-1, -1, -1)])
+            # this is a read
+            with otherwise():
+                with when(io.addr_i[DbgAddressBits-1:0] == WhereToAddr):
+                    # variable ROM content
+                    # variable jump to abstract md, program_buffer or resume
+                    with when(resumereq_wdata_aligned[wdata_hartsel]):
+                        tmp = Wire(U.w(21))
+                        tmp <<= ResumeAddress[11:0] - WhereToAddr
+                        rdata.n <<= CatBits(U.w(32)(0), U.w(11)(0), tmp)
+
+                    # there is a command active so jump there
+                    with when(io.cmdbusy_o):
+                        # transfer not set is shortcut to the program buffer if postexec is set
+                        # keep this statement narrow to not catch invalid commands
+                        with when((cmd_i.cmdtype == AccessRegister) & (~ac_ar.transfer) & ac_ar.postexec):
+                            tmp = Wire(U.w(21))
+                            tmp <<= ProgBufBaseAddr - WhereToAddr
+                            rdata.n <<= CatBits(U.w(32)(0), U.w(11)(0), tmp)
+                        with otherwise():
+                            # this is a legit abstract cmd -> execute it
+                            tmp = Wire(U.w(21))
+                            tmp <<= AbstractCmdBaseAddr - WhereToAddr
+                            rdata.n <<= CatBits(U.w(32)(0), U.w(11)(0), tmp)
+                with elsewhen((io.addr_i[DbgAddressBits-1:0] >= DataBaseAddr) & (io.addr_i[DbgAddressBits-1:0] <= DataEndAddr)):
+                    rdata.n <<= CatBits(io.data_i[io.addr_i[DbgAddressBits-1:3] - DataBaseAddr[DbgAddressBits-1:3] + U(1)],
+                                        io.data_i[io.addr_i[DbgAddressBits-1:3] - DataBaseAddr[DbgAddressBits-1:3]])
+                with elsewhen((io.addr_i[DbgAddressBits-1:0] >= ProgBufBaseAddr) & (io.addr_i[DbgAddressBits-1:0] <= ProgBufEndAddr)):
+                    rdata.n <<= progbuf[io.addr_i[DbgAddressBits-1:3] - ProgBufBaseAddr[DbgAddressBits-1:3]]
+                # two slots for abstract command
+                with elsewhen((io.addr_i[DbgAddressBits-1:0] >= AbstractCmdBaseAddr) & (io.addr_i[DbgAddressBits-1:0] <= AbstractCmdEndAddr)):
+                    # return the correct address index
+                    rdata.n <<= abstract_cmd[io.addr_i[DbgAddressBits-1:3] - AbstractCmdBaseAddr[DbgAddressBits-1:3]]
+                # harts are polling for flags here
+                with elsewhen((io.addr_i[DbgAddressBits-1:0] >= FlagsBaseAddr) & (io.addr_i[DbgAddressBits-1:0] <= FlagsEndAddr)):
+                    # release the corresponding hart
+                    with when(CatBits(io.addr_i[DbgAddressBits-1:3], U.w(3)(0)) - FlagsBaseAddr[DbgAddressBits-1:0] ==
+                              (hartsel & CatBits(CatBits(*[U.w(1)(1) * (DbgAddressBits-3)]), U.w(3)(0)))):
+                        rdata_vec[hartsel & U.w(3)(0x111)] <<= CatBits(U.w(6)(0), resume, go)
+                    rdata.n <<= CatBits(*rdata)
+        io.data_o <<= data_bits
+
+        # this abstract command is currently unsupported
+        unsupported_command <<= Bool(False)
+        # default memory
+        # if ac_ar.transfer si not set then we can take a shortcut to the program buffer
+        abstract_cmd[0] <<= CatBits(Mux(HasSndScratch, auipc(U.w(5)(0x10), U(0)), nop()), illegal())
+        abstract_cmd[1] <<= CatBits(Mux(HasSndScratch, slli(U.w(5)(10), U.w(5)(10), U.w(6)(12)), nop()),
+                                    Mux(HasSndScratch, srli(U.w(5)(10), U.w(5)(10), U.w(6)(12)), nop()))
+        abstract_cmd[2] <<= CatBits(nop(), nop())
+        abstract_cmd[3] <<= CatBits(nop(), nop())
+        abstract_cmd[4] <<= CatBits(ebreak(), Mux(HasSndScratch, csrr(CSR_DSCRATCH1, U.w(5)(10)), nop()))
+        abstract_cmd[5] <<= U(0)
+        abstract_cmd[6] <<= U(0)
+        abstract_cmd[7] <<= U(0)
+
+    return DM_MEM()

--- a/src/debug/dm_pkg.py
+++ b/src/debug/dm_pkg.py
@@ -363,3 +363,13 @@ SBData1      = U.w(8)(0x3D)
 SBData2      = U.w(8)(0x3E)
 SBData3      = U.w(8)(0x3F)
 HaltSum0     = U.w(8)(0x40)
+
+# SBA state
+
+SBA_STATE_E_WIDTH = 3
+
+Idle = U.w(3)(0)
+Read = U.w(3)(1)
+Write = U.w(3)(2)
+WaitRead = U.w(3)(3)
+WaitWrite = U.w(3)(4)

--- a/src/debug/dm_pkg.py
+++ b/src/debug/dm_pkg.py
@@ -25,6 +25,12 @@ DbgVersion013 = U.w(4)(2)
 ProgBufSize = 8             # size of program buffer in junks of 32-bit words
 DataCount = 2               # amount of data count registers implemented
 
+HaltAddress = U.w(64)(0x800)
+ResumeAddress = HaltAddress + U(4)
+ExecptionAddress = HaltAddress + U(8)
+
+DataAddr = U.w(12)(0x380)   # we are aligned with Rocket here
+
 # DTM
 DTM_OP_WIDTH = 2
 
@@ -305,6 +311,32 @@ class sbcs_t:
 #     l.sbaccess16 <<= r.sbaccess16
 #     l.sbaccess8 <<= r.sbaccess8
 
+
+class ac_ar_cmd_t:
+    def __init__(self):
+        self.zero1 = Wire(Bool)
+        self.aarsize = Wire(U.w(3))
+        self.aarpostincrement = Wire(Bool)
+        self.postexec = Wire(Bool)
+        self.transfer = Wire(Bool)
+        self.write = Wire(Bool)
+        self.regno = Wire(U.w(16))
+
+        self.packed = Wire(U.w(32))
+        self.packed <<= CatBits(self.zero1, self.aarsize, self.aarpostincrement, self.postexec,
+                                self.transfer, self.write, self.regno)
+
+        self.clear()
+
+    def clear(self):
+        self.zero1 <<= U(0)
+        self.aarsize <<= U(0)
+        self.aarpostincrement <<= U(0)
+        self.postexec <<= U(0)
+        self.transfer <<= U(0)
+        self.write <<= U(0)
+        self.regno <<= U(0)
+
 # debug registers
 DM_CSR_E_WIDTH = 8
 
@@ -373,3 +405,49 @@ Read = U.w(3)(1)
 Write = U.w(3)(2)
 WaitRead = U.w(3)(3)
 WaitWrite = U.w(3)(4)
+
+# Instruction Generation Helpers
+
+
+def jal(rd, imm):
+    return CatBits(imm[20], imm[10:1], imm[11]. imm[19:12], rd[4:0], U.w(7)(0x6f))
+
+
+def jalr(rd, rs1, offset):
+    return CatBits(offset[11:0], rs1[4:0], U.w(3)(0), rd[4:0], U.w(7)(0x67))
+
+
+def andi(rd, rs1, imm):
+    return CatBits(imm[11:0], rs1[4:0], U.w(3)(0x7), rd[4:0], U.w(7)(0x13))
+
+
+def slli(rd, rs1, shamt):
+    return CatBits(U.w(6)(0), shamt[5:0], rs1[4:0], U.w(3)(1), rd[4:0], U.w(7)(0x13))
+
+
+def srli(rd, rs1, shamt):
+    return CatBits(U.w(6)(0), shamt[5:0], rs1[4:0], U.w(3)(0x5), rd[4:0], U.w(7)(0x13))
+
+
+def load(size, dest, base, offset):
+    return CatBits(offset[11:0], base[4:0], size[2:0], dest[4:0], U.w(7)(0x03))
+
+
+def auipc(rd, imm):
+    return CatBits(imm[20], imm[10:1], imm[11], imm[19:12], rd[4:0], U.w(7)(0x17))
+
+
+def nop():
+    return U.w(32)(0x00000013)
+
+
+def illegal():
+    return U.w(32)(0x00000000)
+
+
+def ebreak():
+    return U.w(32)(0x00100073)
+
+
+def csrr(csr, dest):
+    return CatBits(csr[11:0], U.w(5)(0), U.w(3)(0x2), dest, U.w(7)(0x73))

--- a/src/debug/dm_pkg.py
+++ b/src/debug/dm_pkg.py
@@ -172,6 +172,30 @@ class dmcontrol_t:
 #     l.dmactive <<= r.dmactive
 
 
+class hartinfo_t:
+    def __init__(self):
+        self.zero1 = Wire(U.w(8))
+        self.nscratch = Wire(U.w(4))
+        self.zero0 = Wire(U.w(3))
+        self.dataaccess = Wire(Bool)
+        self.datasize = Wire(U.w(4))
+        self.dataaddr = Wire(U.w(12))
+
+        self.packed = Wire(U.w(32))
+        self.packed <<= CatBits(self.zero1, self.nscratch, self.zero0, self.dataaccess,
+                              self.datasize, self.dataaddr)
+
+        self.clear()
+
+    def clear(self):
+        self.zero1 <<= U(0)
+        self.nscratch <<= U(0)
+        self.zero0 <<= U(0)
+        self.dataaccess <<= U(0)
+        self.datasize <<= U(0)
+        self.dataaddr <<= U(0)
+
+
 class abstractcs_t:
     def __init__(self):
         self.zero3 = Wire(U.w(3))
@@ -292,6 +316,42 @@ class sbcs_t:
         self.sbaccess32 <<= U(0)
         self.sbaccess16 <<= U(0)
         self.sbaccess8 <<= U(0)
+
+
+class dmi_req_t:
+    width = 41
+
+    def __init__(self):
+        self.addr = Wire(U.w(7))
+        self.op = Wire(U.w(DTM_OP_WIDTH))
+        self.ddata = Wire(U.w(32))
+
+        self.packed = Wire(U.w(41))
+        self.packed <<= CatBits(self.addr, self.op, self.ddata)
+
+        self.clear()
+
+    def clear(self):
+        self.addr <<= U(0)
+        self.op <<= U(0)
+        self.ddata <<= U(0)
+
+
+class dmi_resp_t:
+    width = 34
+
+    def __init__(self):
+        self.ddata = Wire(U.w(32))
+        self.resp = Wire(U.w(2))
+
+        self.packed = Wire(U.w(34))
+        self.packed <<= CatBits(self.ddata, self.resp)
+
+        self.clear()
+
+    def clear(self):
+        self.ddata <<= U(0)
+        self.resp <<= U(0)
 
 
 # def con_sbcs_t(l: sbcs_t, r: sbcs_t):
@@ -451,3 +511,19 @@ def ebreak():
 
 def csrr(csr, dest):
     return CatBits(csr[11:0], U.w(5)(0), U.w(3)(0x2), dest, U.w(7)(0x73))
+
+
+def csrw(csr, rs1):
+    return CatBits(csr[11:0], rs1[4:0], U.w(3)(1), U.w(5)(0), U.w(7)(0x73))
+
+
+def store(size, src, base, offset):
+    return CatBits(offset[11:5], src[4:0], base[4:0], size[2:0], offset[4:0], U.w(7)(0x23))
+
+
+def float_load(size, dest, base, offset):
+    return CatBits(offset[11:0], base[4:0], size[2:0], dest[4:0], U.w(7)(0b0000111))
+
+
+def float_store(size, src, base, offset):
+    return CatBits(offset[11:5], src[4:0], base[4:0], size[2:0], offset[4:0], U.w(7)(0b0100111))

--- a/src/debug/dm_sba.py
+++ b/src/debug/dm_sba.py
@@ -1,0 +1,176 @@
+"""
+Copyright Digisim, Computer Architecture team of South China University of Technology,
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   
+   Author Name: Ruohui Chen
+   Date: 2021-05-17
+   File Name: dm_sba.py
+   Description: System Bus Access Module
+"""
+from pyhcl import *
+from src.debug.dm_pkg import *
+from src.include.utils import *
+
+
+def dm_sba(BusWidth: int = 32, ReadByteEnable: bool = True):
+    class DM_SBA(Module):
+        io = IO(
+            dmactive_i=Input(Bool),         # Synchronous reset active low
+
+            master_req_o=Output(Bool),
+            master_add_o=Output(U.w(BusWidth)),
+            master_we_o=Output(Bool),
+            master_wdata_o=Output(U.w(BusWidth)),
+            master_be_o=Output(U.w(int(BusWidth/8))),
+            master_gnt_i=Input(Bool),
+            master_r_valid_i=Input(Bool),
+            master_r_rdata_i=Input(U.w(BusWidth)),
+
+            sbaddress_i=Input(U.w(BusWidth)),
+            sbaddress_write_valid_i=Input(Bool),
+            # control signals in
+            sbreadonaddr_i=Input(Bool),
+            sbaddress_o=Output(U.w(BusWidth)),
+            sbautoincrement_i=Input(Bool),
+            sbaccess_i=Input(U.w(3)),
+            # data in
+            sbreadondata_i=Input(Bool),
+            sbdata_i=Input(U.w(BusWidth)),
+            sbdata_read_valid_i=Input(Bool),
+            sbdata_write_valid_i=Input(Bool),
+            # read data out
+            sbdata_o=Output(U.w(BusWidth)),
+            sbdata_valid_o=Output(Bool),
+            # control signals
+            sbbusy_o=Output(Bool),
+            sberror_valid_o=Output(Bool),       # bus error occurred
+            sberror_o=Output(U.w(3)),           # bus error occurred
+        )
+
+        state = gen_ff(SBA_STATE_E_WIDTH, 0)
+
+        address = Wire(U.w(BusWidth))
+        req = Wire(Bool)
+        gnt = Wire(Bool)
+        we = Wire(Bool)
+        be = Wire(U.w(int(BusWidth/8)))
+        be_mask = Wire(U.w(int(BusWidth/8)))
+        be_idx = Wire(U.w(clog2(BusWidth/8)))
+
+        io.sbbusy_o <<= (state.q == Idle)
+
+        be_mask <<= U(0)
+
+        # generate byte enable mask
+        # helper vec for be_mask
+        be_mask_vec = Wire(Vec(int(BusWidth/8), Bool))
+        for i in range(int(BusWidth/8)):
+            be_mask_vec[i] <<= be_mask[i]
+
+        with when(io.sbaccess_i == U.w(3)(0)):
+            be_mask_vec[be_idx] <<= Bool(True)
+        with elsewhen(io.sbaccess_i == U.w(3)(1)):
+            base_idx = CatBits(be_idx[clog2(BusWidth/8)-1:1], U.w(1)(0))
+            # be_mask_vec[base_idx+U(1):base_idx] <<= U(1)
+            be_mask_vec[base_idx] <<= U(1)
+            be_mask_vec[base_idx+U(1)] <<= U(0)
+        with elsewhen(io.sbaccess_i == U.w(3)(2)):
+            with when(U(BusWidth) == U.w(32)(64)):
+                base_idx = CatBits(be_idx[clog2(BusWidth/8)-1], U.w(2)(0))
+                # be_mask_vec[base_idx+U(3):base_idx] <<= U(1)
+                be_mask_vec[base_idx] <<= U(1)
+                be_mask_vec[base_idx+U(1)] <<= U(0)
+                be_mask_vec[base_idx+U(2)] <<= U(0)
+                be_mask_vec[base_idx+U(3)] <<= U(0)
+            with otherwise():
+                for i in range(int(BusWidth/8)):
+                    if i == 0:
+                        be_mask_vec[i] <<= U(1)
+                    else:
+                        be_mask_vec[i] <<= U(0)
+        be_mask <<= CatBits(*be_mask_vec)
+
+        req <<= Bool(False)
+        address <<= io.sbaddress_i
+        we <<= Bool(False)
+        be <<= Bool(False)
+        be_idx <<= io.sbaddress_i[clog2(BusWidth/8)-1:0]
+
+        io.sberror_o <<= U(0)
+        io.sberror_valid_o <<= Bool(False)
+        io.sbaddress_o <<= io.sbaddress_i
+
+        state.n <<= state.q
+
+        with when(state.q == Idle):
+            # debugger requested a read
+            with when(io.sbaddress_write_valid_i & io.sbreadonaddr_i):
+                state.n <<= Read
+            # debugger requested a write
+            with when(io.sbdata_write_valid_i):
+                state.n <<= Write
+            # perform another read
+            with when(io.sbdata_read_valid_i & io.sbreadondata_i):
+                state.n <<= Read
+        with elsewhen(state.q == Read):
+            req <<= Bool(True)
+            with when(U(ReadByteEnable)):
+                be <<= be_mask
+            with when(gnt):
+                state.n <<= WaitRead
+        with elsewhen(state.q == Write):
+            req <<= Bool(True)
+            we <<= Bool(True)
+            be <<= be_mask
+            with when(gnt):
+                state.n <<= WaitWrite
+        with elsewhen(state.q == WaitRead):
+            with when(io.sbdata_valid_o):
+                state.n <<= Idle
+                # auto-increment address
+                with when(io.sbautoincrement_i):
+                    io.sbaddress_o <<= io.sbaddress_i + (U.w(32)(1) << io.sbaccess_i)
+        with elsewhen(state.q == WaitWrite):
+            with when(io.sbdata_valid_o):
+                state.n <<= Idle
+                # auto-increment address
+                with when(io.sbautoincrement_i):
+                    io.sbaddress_o <<= io.sbaddress_i + (U.w(32)(1) << io.sbaccess_i)
+        with otherwise():
+            state.n <<= Idle    # Catch parasitic state
+
+        # handle error case
+        with when((io.sbaccess_i > U(0)) & (state.q != Idle)):
+            req <<= Bool(False)
+            state.n <<= Idle
+            io.sberror_valid_o <<= Bool(True)
+            io.sberror_o <<= U.w(3)(3)
+
+        # ff
+        state.q <<= state.n
+
+        io.master_req_o <<= req
+        io.master_add_o <<= address[BusWidth-1:0]
+        io.master_we_o <<= we
+        io.master_wdata_o <<= io.sbdata_i[BusWidth-1:0]
+        io.master_be_o <<= be[int(BusWidth/8)-1:0]
+        gnt <<= io.master_gnt_i
+        io.sbdata_valid_o <<= io.master_r_valid_i
+        io.sbdata_o <<= io.master_r_rdata_i[BusWidth-1:0]
+
+    return DM_SBA()
+
+
+if __name__ == '__main__':
+    Emitter.dumpVerilog_nock(Emitter.dump(Emitter.emit(dm_sba()), "dm_sba.fir"))

--- a/src/debug/dm_top.py
+++ b/src/debug/dm_top.py
@@ -1,0 +1,237 @@
+"""
+Copyright Digisim, Computer Architecture team of South China University of Technology,
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   
+   Author Name: Ruohui Chen
+   Date: 2021-05-20
+   File Name: dm_top.py
+   Description: Top-level of debug module (DM). This is an AXI-Slave.
+                DTM protocol is equal to SiFives debug protocol to leverage
+                SW infrastructure re-use. As of version 0.13.
+"""
+from pyhcl import *
+from src.debug.dm_pkg import *
+from src.debug.dm_csrs import *
+from src.debug.dm_sba import *
+from src.debug.dm_mem import *
+
+
+def dm_top(NrHarts: int = 1, BusWidth: int = 32):
+    # local parameters
+    DmBaseAddress = U(0x1000)   # default to non-zero page
+    # Bitmask to select physically available harts for systems
+    # that don't use hart numbers in a contiguous fashion.
+    SelectableHarts = CatBits(*[U.w(1)(1) for _ in range(NrHarts)])
+    ReadByteEnable = 1
+
+    class DM_TOP(Module):
+        io = IO(
+            testmode_i=Input(Bool),
+            ndmreset_o=Output(Bool),            # non-debug module reset
+            dmactive_o=Output(Bool),            # debug module is active
+            debug_req_o=Output(U.w(NrHarts)),   # async debug request
+            unavailable_i=Input(U.w(NrHarts)),  # communicate whether the hart is unavailable (e.g.: power down)
+            hartinfo_i=Input(Vec(NrHarts, U.w(32))),
+
+            slave_req_i=Input(Bool),
+            slave_we_i=Input(Bool),
+            slave_addr_i=Input(U.w(BusWidth)),
+            slave_be_i=Input(U.w(int(BusWidth/8))),
+            slave_wdata_i=Input(U.w(BusWidth)),
+            slave_rdata_o=Output(U.w(BusWidth)),
+
+            master_req_o=Output(Bool),
+            master_add_o=Output(U.w(BusWidth)),
+            master_we_o=Output(Bool),
+            master_wdata_o=Output(U.w(BusWidth)),
+            master_be_o=Output(U.w(int(BusWidth/8))),
+            master_gnt_i=Input(Bool),
+            master_r_valid_i=Input(Bool),
+            master_r_rdata_i=Input(U.w(BusWidth)),
+
+            # Connection to DTM - compatible to RocketChip Debug Module
+            dmi_rst_ni=Input(Bool),
+            dmi_req_valid_i=Input(Bool),
+            dmi_req_ready_o=Output(Bool),
+            dmi_req_i=Input(U.w(41)),
+
+            dmi_resp_valid_o=Output(Bool),
+            dmi_resp_ready_i=Input(Bool),
+            dmi_resp_o=Output(U.w(34))
+        )
+        dm_csrs_i = dm_csrs().io
+        dm_sba_i = dm_sba().io
+        dm_mem_i = dm_mem().io
+
+        hartinfo_i = hartinfo_t()
+        dmi_req_i = dmi_req_t()
+        dmi_resp_o = dmi_resp_t()
+        hartinfo_i.packed <<= io.hartinfo_i[0]
+        dmi_req_i.packed <<= io.dmi_req_i
+
+        halted = Wire(U.w(NrHarts))
+        resumeack = Wire(U.w(NrHarts))
+        haltreq = Wire(U.w(NrHarts))
+        resumereq = Wire(U.w(NrHarts))
+        clear_resumeack = Wire(Bool)
+        cmd_valid = Wire(Bool)
+        cmd = command_t(False)
+
+        cmderror_valid = Wire(Bool)
+        cmderror = Wire(U.w(CMDERR_E_WIDTH))
+        cmdbusy = Wire(Bool)
+        progbuf = Wire(Vec(ProgBufSize, U.w(32)))
+        data_csrs_mem = Wire(Vec(DataCount, U.w(32)))
+        data_mem_csrs = Wire(Vec(DataCount, U.w(32)))
+        data_valid = Wire(Bool)
+        hartsel = Wire(U.w(20))
+
+        # System Bus Access Module
+        sbaddress_csrs_sba = Wire(U.w(BusWidth))
+        sbaddress_sba_csrs = Wire(U.w(BusWidth))
+        sbaddress_write_valid = Wire(Bool)
+        sbreadonaddr = Wire(Bool)
+        sbautoincrement = Wire(Bool)
+        # logic [2:0]                       sbaccess;
+        sbaccess = Wire(U.w(3))
+        sbreadondata = Wire(Bool)
+        # logic [BusWidth-1:0]              sbdata_write;
+        sbdata_write = Wire(U.w(BusWidth))
+        sbdata_read_valid = Wire(Bool)
+        sbdata_write_valid = Wire(Bool)
+        # logic [BusWidth-1:0]              sbdata_read;
+        sbdata_read = Wire(U.w(BusWidth))
+        sbdata_valid = Wire(Bool)
+        sbbusy = Wire(Bool)
+        sberror_valid = Wire(Bool)
+        # logic [2:0]                       sberror;
+        sberror = Wire(U.w(3))
+
+        # -----------------------
+        # dm_csrs
+        # -----------------------
+        io.dmactive_o <<= dm_csrs_i.dmactive_o
+        dm_csrs_i.testmode_i <<= io.testmode_i
+        dm_csrs_i.dmi_rst_ni <<= io.dmi_rst_ni
+        dm_csrs_i.dmi_req_valid_i <<= io.dmi_req_valid_i
+        io.dmi_req_ready_o <<= dm_csrs_i.dmi_req_ready_o
+        dm_csrs_i.dmi_req_i_addr <<= dmi_req_i.addr
+        dm_csrs_i.dmi_req_i_op <<= dmi_req_i.op
+        dm_csrs_i.dmi_req_i_data <<= dmi_req_i.ddata
+        io.dmi_resp_valid_o <<= dm_csrs_i.dmi_resp_valid_o
+        dm_csrs_i.dmi_resp_ready_i <<= io.dmi_resp_ready_i
+        dmi_resp_o.ddata <<= dm_csrs_i.dmi_resp_o_data
+        dmi_resp_o.resp <<= dm_csrs_i.dmi_resp_o_resp
+        io.ndmreset_o <<= dm_csrs_i.ndmreset_o
+        hartsel <<= dm_csrs_i.hartsel_o
+        dm_csrs_i.hartinfo_i_zero1[0] <<= hartinfo_i.zero0
+        dm_csrs_i.hartinfo_i_nscratch[0] <<= hartinfo_i.nscratch
+        dm_csrs_i.hartinfo_i_zero0[0] <<= hartinfo_i.zero0
+        dm_csrs_i.hartinfo_i_dataaccess[0] <<= hartinfo_i.dataaccess
+        dm_csrs_i.hartinfo_i_datasize[0] <<= hartinfo_i.datasize
+        dm_csrs_i.hartinfo_i_dataaddr[0] <<= hartinfo_i.dataaddr
+        dm_csrs_i.halted_i <<= halted
+        dm_csrs_i.unavailable_i <<= io.unavailable_i
+        dm_csrs_i.resumeack_i <<= resumeack
+        haltreq               <<= dm_csrs_i.haltreq_o
+        resumereq             <<= dm_csrs_i.resumereq_o
+        clear_resumeack       <<= dm_csrs_i.clear_resumeack_o
+        cmd_valid             <<= dm_csrs_i.cmd_valid_o
+        cmd.cmdtype                   <<= dm_csrs_i.cmd_o_cmd_e
+        cmd.control                   <<= dm_csrs_i.cmd_o_control
+        dm_csrs_i.cmderror_valid_i <<= cmderror_valid        
+        dm_csrs_i.cmderror_i <<= cmderror              
+        dm_csrs_i.cmdbusy_i <<= cmdbusy               
+        progbuf               <<= dm_csrs_i.progbuf_o
+        dm_csrs_i.data_i <<= data_mem_csrs         
+        dm_csrs_i.data_valid_i <<= data_valid            
+        data_csrs_mem         <<= dm_csrs_i.data_o
+        sbaddress_csrs_sba    <<= dm_csrs_i.sbaddress_o
+        dm_csrs_i.sbaddress_i <<= sbaddress_sba_csrs    
+        sbaddress_write_valid <<= dm_csrs_i.sbaddress_write_valid_o
+        sbreadonaddr          <<= dm_csrs_i.sbreadonaddr_o
+        sbautoincrement       <<= dm_csrs_i.sbautoincrement_o
+        sbaccess              <<= dm_csrs_i.sbaccess_o
+        sbreadondata          <<= dm_csrs_i.sbreadondata_o
+        sbdata_write          <<= dm_csrs_i.sbdata_o
+        sbdata_read_valid     <<= dm_csrs_i.sbdata_read_valid_o
+        sbdata_write_valid    <<= dm_csrs_i.sbdata_write_valid_o
+        dm_csrs_i.sbdata_i <<= sbdata_read           
+        dm_csrs_i.sbdata_valid_i <<= sbdata_valid          
+        dm_csrs_i.sbbusy_i <<= sbbusy                
+        dm_csrs_i.sberror_valid_i <<= sberror_valid         
+        dm_csrs_i.sberror_i <<= sberror
+        io.dmi_resp_o <<= dmi_resp_o.packed
+
+        # -----------------------
+        # dm_sba
+        # -----------------------
+        dm_sba_i.dmactive_i <<= io.dmactive_o
+        
+        io.master_req_o <<= dm_sba_i.master_req_o
+        io.master_add_o <<= dm_sba_i.master_add_o
+        io.master_we_o <<= dm_sba_i.master_we_o
+        io.master_wdata_o <<= dm_sba_i.master_wdata_o
+        io.master_be_o <<= dm_sba_i.master_be_o
+        dm_sba_i.master_gnt_i <<= io.master_gnt_i
+        dm_sba_i.master_r_valid_i <<= io.master_r_valid_i
+        dm_sba_i.master_r_rdata_i <<= io.master_r_rdata_i
+
+        dm_sba_i.sbaddress_i <<= sbaddress_csrs_sba
+        sbaddress_sba_csrs <<= dm_sba_i.sbaddress_o
+        dm_sba_i.sbaddress_write_valid_i <<= sbaddress_write_valid
+        dm_sba_i.sbreadonaddr_i <<= sbreadonaddr
+        dm_sba_i.sbautoincrement_i <<= sbautoincrement
+        dm_sba_i.sbaccess_i <<= sbaccess
+        dm_sba_i.sbreadondata_i <<= sbreadondata
+        dm_sba_i.sbdata_i <<= sbdata_write
+        dm_sba_i.sbdata_read_valid_i <<= sbdata_read_valid
+        dm_sba_i.sbdata_write_valid_i <<= sbdata_write_valid
+        sbdata_read <<= dm_sba_i.sbdata_o
+        sbdata_valid <<= dm_sba_i.sbdata_valid_o
+        sbbusy <<= dm_sba_i.sbbusy_o
+        sberror_valid <<= dm_sba_i.sberror_valid_o
+        sberror <<= dm_sba_i.sberror_o
+
+        # -----------------------
+        # dm_mem
+        # -----------------------
+        io.debug_req_o <<= dm_mem_i.debug_req_o
+        dm_mem_i.hartsel_i <<= hartsel
+        dm_mem_i.haltreq_i <<= haltreq
+        dm_mem_i.resumereq_i <<= resumereq
+        dm_mem_i.clear_resumeack_i <<= clear_resumeack
+        halted <<= dm_mem_i.halted_o
+        resumeack <<= dm_mem_i.resuming_o
+        dm_mem_i.cmd_valid_i <<= cmd_valid
+        dm_mem_i.cmd_i <<= cmd.packed
+        cmderror_valid <<= dm_mem_i.cmderror_valid_o
+        cmderror <<= dm_mem_i.cmderror_o
+        cmdbusy <<= dm_mem_i.cmdbusy_o
+        dm_mem_i.progbuf_i <<= progbuf
+        dm_mem_i.data_i <<= data_csrs_mem
+        data_mem_csrs <<= dm_mem_i.data_o
+        data_valid <<= dm_mem_i.data_valid_o
+        dm_mem_i.req_i <<= io.slave_req_i
+        dm_mem_i.we_i <<= io.slave_we_i
+        dm_mem_i.addr_i <<= io.slave_addr_i
+        dm_mem_i.wdata_i <<= io.slave_wdata_i
+        dm_mem_i.be_i <<= io.slave_be_i
+        io.slave_rdata_o <<= dm_mem_i.rdata_o
+
+    return DM_TOP()
+
+
+if __name__ == '__main__':
+    Emitter.dumpVerilog_nock(Emitter.dump(Emitter.emit(dm_top()), "dm_top.fir"))

--- a/src/debug/dmi_jtag.py
+++ b/src/debug/dmi_jtag.py
@@ -1,0 +1,25 @@
+"""
+Copyright Digisim, Computer Architecture team of South China University of Technology,
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+   
+   Author Name: Ruohui Chen
+   Date: 2021-05-21
+   File Name: dmi_jtag.py
+   Description: JTAG TAP for DMI (according to debug spec 0.13)
+"""
+
+"""
+PyHCL temporary doesn't support multiple clocks, please use blackbox or original Systemverilog
+code to do so.
+"""

--- a/src/include/utils.py
+++ b/src/include/utils.py
@@ -59,6 +59,18 @@ def vec_init(size, el, init):
     return tmp
 
 
+def vec_init_wire(size, el, init):
+    tmp = Wire(Vec(size, el))
+    for i in range(size):
+        tmp[i] <<= init
+    return tmp
+
+
+def vec_assign(size, v, rhs):
+    for i in range(size):
+        v[i] <<= rhs[i]
+
+
 def clog2(v):
     return ceil(log(v, 2))
 


### PR DESCRIPTION
Debug feature implementation, according to debug SPEC 0.13. @giraffe50 
Be noticed: due to the limited support for multiple clocks in PyHCL, JTAG dmi interface need to use original Systemverilog code. (CDC required)